### PR TITLE
Remove navigation components from home and profile pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,26 +43,7 @@ export default function Home() {
         </div>
       </div>
 
-      {/* Bottom navigation */}
-      <div className="relative z-10 bg-red-950 h-20 flex items-center justify-center px-4">
-        <nav className="flex items-center justify-center gap-8 md:gap-12 w-full max-w-md">
-          <Link
-            href="/people"
-            className="bg-white text-black px-5 py-2 rounded text-xs font-normal hover:bg-gray-100 transition-colors"
-          >
-            People
-          </Link>
-          <button className="text-white text-xs font-normal hover:text-gray-300 transition-colors">
-            Gallery
-          </button>
-          <Link
-            href="/profile"
-            className="text-white text-xs font-normal hover:text-gray-300 transition-colors"
-          >
-            My Profile
-          </Link>
-        </nav>
-      </div>
+
     </div>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,16 +3,7 @@ import Link from "next/link";
 export default function Profile() {
   return (
     <div className="min-h-screen bg-black flex flex-col">
-      {/* Header with back button */}
-      <div className="px-6 py-4">
-        <Link
-          href="/people"
-          className="text-white text-xs font-normal flex items-center gap-1 hover:text-gray-300 transition-colors"
-        >
-          <span>{"<"}</span>
-          <span>People</span>
-        </Link>
-      </div>
+
 
       {/* Profile Content */}
       <div className="flex-1 flex flex-col items-center px-6 py-8">


### PR DESCRIPTION
This change removes navigation elements from two pages:

- Removes the bottom navigation bar from the home page (src/app/page.tsx)
  - Deleted the entire navigation section containing People, Gallery, and My Profile links
  - Removed the red background container and associated styling

- Removes the header navigation from the profile page (src/app/profile/page.tsx)
  - Deleted the back button link to the People page
  - Removed the header container and padding

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c3b2ecda8aa4d1fbb57c102e5981ee6/mystic-oasis)

👀 [Preview Link](https://4c3b2ecda8aa4d1fbb57c102e5981ee6-mystic-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c3b2ecda8aa4d1fbb57c102e5981ee6</projectId>-->
<!--<branchName>mystic-oasis</branchName>-->